### PR TITLE
misc: add link to slackarchive

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,8 @@
           <p>
             <a href="https://medium.com/tech-masters/">Blog</a>
             <a href="/events/">Events</a>
-            <a href="/conduct/">Code of Conduct</a> 
+            <a href="/conduct/">Code of Conduct</a>
+            <a href="http://techmasters.slackarchive.io/" target="_blank">Archive</a>
           </p>
         </nav>
       </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,7 @@
 <html>
   {% include head.html %}
 
-  <body>
+  <body class="page-{{ page.title | slugify }}">
     {% include header.html %}
 
     {{ content }}

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -394,6 +394,7 @@ p.author {
   a {
     display: inline-block;
     margin-right: 20px;
+    margin-bottom: 10px;
   }
 }
 

--- a/_sass/_events.scss
+++ b/_sass/_events.scss
@@ -19,7 +19,7 @@
         white-space: nowrap;
     }
 
-    .noevents {
+    .no-events {
       &:not(:first-child) {
         display: none;
       }

--- a/events/index.html
+++ b/events/index.html
@@ -20,7 +20,7 @@ title: Events
             <hr/>
             <p v-if="event.description">[!!event.description!!]</p>
         </li>
-        <li class="list-group-item noevents">
+        <li class="list-group-item no-events">
           No upcoming events
         </li>
     </ul>


### PR DESCRIPTION
- Add link to Slackarchive in footer. I cannot use iframes because they don't allow cross-origin embedding #35 
- Add body class for current page
- Add margin-bottom to footer links (they were too tight before)
- Fix CSS naming in events page h/t @Soviut https://github.com/TechnologyMasters/technologymasters.github.io/pull/38#commitcomment-19353811
