### PR TITLE
feat(conduct): add permalinks to h4 headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 .sass-cache
 _site
 Gemfile.lock
-.vagrant

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .sass-cache
 _site
 Gemfile.lock
+.vagrant

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -7,3 +7,5 @@ layout: default
     {{ content }}
   </div>
 </div>
+
+<script src="/assets/js/page.js"></script>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -45,6 +45,15 @@
   max-width: 1600px;
   width: calc(100% - 16px);
   margin: 0 auto;
+
+  h4 a {
+    text-decoration: none;
+    color: inherit;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 }
 
 .mdl-layout-title {
@@ -57,10 +66,6 @@
 }
 
 @media screen and (max-width: 1024px) {
-  .tm-content {
-    padding: 40px 28px;
-  }
-
   h2 {
     font-size: 1.8rem;
     line-height: 1.3;
@@ -81,10 +86,25 @@
 
 .tm-content {
   border-radius: 2px;
-  padding: 60px;
+  padding: 20px;
   margin-bottom: 60px;
+
+  @media (min-width: 480px) {
+    padding: 40px 28px;
+  }
+  @media (min-width: 768px) {
+    padding: 60px;
+  }
 
   h3 {
     margin-top: 48px;
   }
+}
+
+/**
+ * Material Lite Overrides
+ */
+
+.mdl-layout {
+  height: auto;
 }

--- a/assets/js/page.js
+++ b/assets/js/page.js
@@ -1,0 +1,12 @@
+function setPermalinks () {
+  var headers = document.querySelectorAll('.tm-container h4')
+
+  // Apply permalinks to headers
+  if (headers.length > 0) {
+    Array.prototype.forEach.call(headers, function (el, i) {
+      el.innerHTML = '<a href="#' + el.id + '">' + el.innerHTML + '</a>'
+    })
+  }
+}
+
+setPermalinks()

--- a/assets/js/page.js
+++ b/assets/js/page.js
@@ -1,4 +1,4 @@
-function setPermalinks () {
+function applyPermalinks () {
   var headers = document.querySelectorAll('.tm-container h4')
 
   // Apply permalinks to headers
@@ -9,4 +9,4 @@ function setPermalinks () {
   }
 }
 
-setPermalinks()
+applyPermalinks()


### PR DESCRIPTION
On conduct page:

- On load, set `H4`s to permalinks for easy linking to particular sections
- Bonus: set padding to be more mobile-friendly

See #53

![animation](https://cloud.githubusercontent.com/assets/12798751/20041568/3d211bd4-a439-11e6-9399-07cb4c862978.gif)
