### PR TITLE
feat(nav): add link to GitHub job board

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,6 +32,7 @@
           <a class="mdl-navigation__link" href="https://techmasters.blog/">Blog</a>
           <a class="mdl-navigation__link" href="https://www.meetup.com/tech-masters-toronto/">Meetup</a>
           <a class="mdl-navigation__link" href="/events">Events</a>
+          <a class="mdl-navigation__link" href="https://github.com/TechnologyMasters/jobs/issues">Job Board</a>
           <a class="mdl-navigation__link" href="http://techmasters.slackarchive.io/">Archive</a>
           <a class="mdl-navigation__link" href="/conduct">Code of Conduct</a>
         </nav>


### PR DESCRIPTION
Starting small, then moving towards a complete job board that hooks from GitHub.

See #68 

![image](https://user-images.githubusercontent.com/12798751/31050614-8d9c3454-a61d-11e7-817d-65799501cf34.png)