### PR TITLE
fix: add colour contrast to links

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -14,3 +14,11 @@ h2 {
   font-size: 2.8rem;
   margin: 0;
 }
+
+a {
+ color: #9c6c2d;
+
+ &:hover {
+   text-decoration: none;
+ }
+}


### PR DESCRIPTION
I don't know a lot about colour theory, but I am hoping to improve the colour contrast on those orange links.

I went with this brownish colour based off the site's purple accent. I'm happy to amend commits after your suggestions.

![image](https://user-images.githubusercontent.com/12798751/84723940-e0b08580-af54-11ea-8d99-02ad78714a1d.png)

![image](https://user-images.githubusercontent.com/12798751/84723949-e4440c80-af54-11ea-963b-0b0490c758c2.png)
