### PR TITLE
fix(home): Use Discord for signups

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Logo](assets/images/brand/logo-full.png)
 
-The official website for the [**#TechMasters**][website] Slack Group's website: [TechMasters.chat][website]
+The official website for the [**#TechMasters**][website] Discord Group's website: [TechMasters.chat][website]
 
 The site is published using [Jekyll](https://jekyllrb.com), and hosted on [GitHub Pages](https://help.github.com/articles/about-github-pages-and-jekyll/).
 

--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ description: Connect with fellow Technologists &amp; Founders, Get help with cod
 # Build settings
 markdown: kramdown
 
-slack: https://join.slack.com/t/techmasters/shared_invite/zt-1ucbguzlt-Fe8B0VJrzB~d13z9Uc8gMw
+discord: https://discord.gg/Ft8yU3Mkep
 
 # Google Calendar API settings
 googleCalendar:

--- a/conduct/index.md
+++ b/conduct/index.md
@@ -17,7 +17,7 @@ By joining and participating in the TechMasters community, you agree to abide by
 3. **Use The Jobs Board** — All job postings must be posted through the jobs board at <https://techmasters.chat/jobs>. No job may be posted that involves any illegal activity in the jurisdiction in which the job is located. Job templates must be closely followed, otherwise they may get closed.
 4. **Be Friendly and Respectful** — No harassment, hate speech, racism, sexism, malicious trolling, etc. You may be banned immediately and without warning or recourse. Additionally, be aware we have an incredibly varied user base when it comes to knowledge, so please be patient and help each other.
 5. **No NSFW or Obscene Content** — This includes text, images, or links featuring nudity, sex, hard violence, or other graphically disturbing content.
-6. **Keep It Legal** — No piracy or illegal activities. All users are responsible for following both the [Slack User Terms of Service](https://slack.com/terms-of-service/user) and the [Slack Acceptable Use Policy](https://slack.com/acceptable-use-policy).
+6. **Keep It Legal** — No piracy or illegal activities. All users are responsible for following both the [Discord User Terms of Service](https://discord.com/terms) and the [Discord Community Guidelines](https://discord.com/guidelines).
 7. **Be Relevant** — Be mindful of channels and their topics. Failure to do so may result in loss of access to the channel or the community.
 8. **Keep Politics In Their Place** — No political discussions outside of #politics, or when relevant, #world and #canadia.
 9. **Protect Your Privacy & Security** — Be cautious about giving out personally identifiable information to strangers online, which may be used against you. This is also a public community that anyone can join and read, so be mindful of what you diclose about yourself or your company. Be sure to use 2FA.
@@ -27,8 +27,9 @@ By joining and participating in the TechMasters community, you agree to abide by
 
 #### Administrators
 
-- **Ahmad Nassri** - Contact [@ahmadnassri on Slack](https://techmasters.slack.com/messages/@ahmadnassri) or [by email](mailto:ahmad@techmasters.email).
-- **Andrew Moore** - Contact [@awmoore on Slack](https://techmasters.slack.com/messages/@awmoore) or [by email](mailto:andrew@techmasters.email).
+- **Ahmad Nassri** - Contact [by email](mailto:ahmad@techmasters.email).
+- **Andrew Moore** - Contact [by email](mailto:andrew@techmasters.email).
+<!-- 
 - View the rest of our Admins by navigating to the [Team page](https://techmasters.slack.com/team) or by selecting "People & user groups" under "More" in the Slack application's sidebar then using the filter option to view all of the Admins.
-
+-->
 Thanks for following this Code of Conduct and joining the TechMasters community!

--- a/conduct/index.md
+++ b/conduct/index.md
@@ -4,7 +4,7 @@ title: Code of Conduct
 redirect_from: "/coc/"
 ---
 
-Last modified: August 17, 2021
+Last modified: May 24, 2023
 
 #### Welcome to the TechMasters Community!
 

--- a/conduct/index.md
+++ b/conduct/index.md
@@ -29,7 +29,5 @@ By joining and participating in the TechMasters community, you agree to abide by
 
 - **Ahmad Nassri** - Contact [by email](mailto:ahmad@techmasters.email).
 - **Andrew Moore** - Contact [by email](mailto:andrew@techmasters.email).
-<!-- 
-- View the rest of our Admins by navigating to the [Team page](https://techmasters.slack.com/team) or by selecting "People & user groups" under "More" in the Slack application's sidebar then using the filter option to view all of the Admins.
--->
+
 Thanks for following this Code of Conduct and joining the TechMasters community!

--- a/conduct/index.md
+++ b/conduct/index.md
@@ -27,7 +27,11 @@ By joining and participating in the TechMasters community, you agree to abide by
 
 #### Administrators
 
-- **Ahmad Nassri** - Contact [by email](mailto:ahmad@techmasters.email).
-- **Andrew Moore** - Contact [by email](mailto:andrew@techmasters.email).
+Should you need to contact our Administrators, please send us a DM.
+
+- **Ahmad Nassri** - [Discord Profile](https://discordapp.com/users/292713944060002315).
+- **Andrew Moore** - [Discord Profile](https://discordapp.com/users/172908093150068736).
+
+_Note: Direct links to our Discord profiles may not work if you open them in the desktop client. You may instead open them in your web browser._
 
 Thanks for following this Code of Conduct and joining the TechMasters community!

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@ partners:
   >
     <div class="mdl-grid">
       <div class="mdl-cell mdl-cell--12-col">
-        <h3>Join our Slack community!</h3>
+        <h3>Join our Discord community!</h3>
         <legend class="tm-signup" id="signup">
           <p>
             By choosing to join the TechMasters community, you agree to the
@@ -91,7 +91,7 @@ partners:
           class="mdl-button mdl-button--colored mdl-button--raised mdl-js-button mdl-js-ripple-effect"
           href=""
           aria-describedby="formWarning"
-          >Join our Slack Network</a
+          >Join our Discord Network</a
         >
         <span
           id="formWarning"
@@ -103,7 +103,7 @@ partners:
 
         <script>
           // form validation
-          var url = "{{ site.slack }}";
+          var url = "{{ site.discord }}";
           var warningOpen =
             'You must agree to our code of conduct by checking the boxes above. <a href="#wontAbuse" role="button" draggable="false">Go to first checkbox</a>';
 
@@ -180,7 +180,7 @@ partners:
   </div>
   {% endfor %}
 
-  <div class="mdl-cell mdl-cell--12-col">
+<!--  <div class="mdl-cell mdl-cell--12-col">
     <h3 class="mdl-typography--text-center mdl-color-text--primary-dark">
       Featured Channels
     </h3>
@@ -205,3 +205,4 @@ partners:
   </div>
   {% endfor %}
 </div>
+-->


### PR DESCRIPTION
Also change content related to slack

and comment out the list of channels for now until we figure out how to direct link to discord channels if possible